### PR TITLE
Added Adminhtml inherited controller

### DIFF
--- a/app/code/community/ZerebroInternet/Barzahlen/Model/Observer.php
+++ b/app/code/community/ZerebroInternet/Barzahlen/Model/Observer.php
@@ -17,7 +17,7 @@ class ZerebroInternet_Barzahlen_Model_Observer
         $block = $observer->getBlock();
         $type = $block->getType();
 
-        if($type == 'adminhtml/sales_order_view') {
+        if ($type == 'adminhtml/sales_order_view') {
             $order = $block->getOrder();
             $paymentMethod = $order->getPayment()->getMethod();
 
@@ -29,10 +29,10 @@ class ZerebroInternet_Barzahlen_Model_Observer
                 $message = Mage::helper('sales')->__('bz_adm_resend_payment_slip_question');
                 $block->addButton('payment_slip_resend', array(
                     'label' => Mage::helper('barzahlen')->__('bz_adm_resend_payment_slip'),
-                    'onclick' => "confirmSetLocation('{$message}', '{$block->getUrl('barzahlen/resend/payment', array('order_id' => $order->getId()))}')"
+                    'onclick' => "confirmSetLocation('{$message}', '{$block->getUrl('*/resend/payment', array('order_id' => $order->getId()))}')"
                 ), 0, 100, 'header');
             }
-        } elseif ($type == 'adminhtml/sales_order_creditmemo_view'){
+        } elseif ($type == 'adminhtml/sales_order_creditmemo_view') {
             $creditMemo = $block->getCreditmemo();
             $paymentMethod = $creditMemo->getOrder()->getPayment()->getMethod();
 
@@ -40,7 +40,7 @@ class ZerebroInternet_Barzahlen_Model_Observer
                 $message = Mage::helper('sales')->__('bz_adm_resend_refund_slip_question');
                 $block->addButton('refund_slip_resend', array(
                     'label' => Mage::helper('barzahlen')->__('bz_adm_resend_refund_slip'),
-                    'onclick' => "confirmSetLocation('{$message}', '{$block->getUrl('barzahlen/resend/refund', array('creditmemo_id' => $creditMemo->getId()))}')"
+                    'onclick' => "confirmSetLocation('{$message}', '{$block->getUrl('*/resend/refund', array('creditmemo_id' => $creditMemo->getId()))}')"
                 ), 0, 100, 'header');
             }
         }

--- a/app/code/community/ZerebroInternet/Barzahlen/controllers/Adminhtml/ResendController.php
+++ b/app/code/community/ZerebroInternet/Barzahlen/controllers/Adminhtml/ResendController.php
@@ -10,7 +10,7 @@
  * @license     http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL-3.0)
  */
 
-class ZerebroInternet_Barzahlen_ResendController extends Mage_Adminhtml_Controller_Action
+class ZerebroInternet_Barzahlen_Adminhtml_ResendController extends Mage_Adminhtml_Controller_Action
 {
     /**
      * Handles payment slip resend requests.
@@ -37,9 +37,9 @@ class ZerebroInternet_Barzahlen_ResendController extends Mage_Adminhtml_Controll
     public function refundAction()
     {
         $id = $this->getRequest()->getParam('creditmemo_id');
-        $creditmemo = Mage::getModel('sales/order_creditmemo')->load($id);
+        $creditMemo = Mage::getModel('sales/order_creditmemo')->load($id);
 
-        $transactionId = $creditmemo->getTransactionId();
+        $transactionId = $creditMemo->getTransactionId();
 
         if (Mage::getSingleton('barzahlen/barzahlen')->resendSlip($transactionId)) {
             $this->_getSession()->addSuccess($this->__('bz_adm_resend_refund_success'));
@@ -49,4 +49,10 @@ class ZerebroInternet_Barzahlen_ResendController extends Mage_Adminhtml_Controll
 
         $this->_redirect('adminhtml/sales_order_creditmemo/view', array('creditmemo_id' => $id));
     }
+
+    protected function _isAllowed()
+    {
+        return Mage::getSingleton('admin/session')->isAllowed('sales/order/barzahlen_actions');
+    }
+
 }

--- a/app/code/community/ZerebroInternet/Barzahlen/etc/adminhtml.xml
+++ b/app/code/community/ZerebroInternet/Barzahlen/etc/adminhtml.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+<config>
+    <acl>
+        <resources>
+            <admin>
+                <children>
+                    <sales>
+                        <children>
+                            <order>
+                                <children>
+                                    <barzahlen_actions translate="title">
+                                        <title>Barzahlen Actions</title>
+                                        <sort_order>200</sort_order>
+                                    </barzahlen_actions>
+                                </children>
+                            </order>
+                        </children>
+                    </sales>
+                </children>
+            </admin>
+        </resources>
+    </acl>
+</config>

--- a/app/code/community/ZerebroInternet/Barzahlen/etc/config.xml
+++ b/app/code/community/ZerebroInternet/Barzahlen/etc/config.xml
@@ -15,7 +15,7 @@
 
     <modules>
         <ZerebroInternet_Barzahlen>
-            <version>1.3.4</version>
+            <version>1.3.5</version>
         </ZerebroInternet_Barzahlen>
     </modules>
 
@@ -88,6 +88,18 @@
             </modules>
         </translate>
     </frontend>
+
+    <admin>
+        <routers>
+            <adminhtml>
+                <args>
+                    <modules>
+                        <barzahlen before="Mage_Adminhtml">ZerebroInternet_Barzahlen_Adminhtml</barzahlen>
+                    </modules>
+                </args>
+            </adminhtml>
+        </routers>
+    </admin>
 
     <adminhtml>
         <events>


### PR DESCRIPTION
This fixes module working after recent Magento patches, mainly SUPEE-5994 which introduces strict check for admin controllers but also SUPEE-6285 by adding _isAllowed() check
